### PR TITLE
Fix non-boot condition after building FW in latest platformio

### DIFF
--- a/buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08007000
@@ -5,4 +6,10 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/STM32F1_SKR_MINI.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/STM32F1_SKR_MINI.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script


### PR DESCRIPTION
There is a problem compiling SKR Mini FW in the latest version of platformIO, the firmware.bin that is generated will prevent the board from booting. This edit will fix the issue.